### PR TITLE
[Feat] [SCRUM-56] 계정 잠금 상태 변경 

### DIFF
--- a/src/main/java/com/sprint/otboo/common/config/SecurityConfig.java
+++ b/src/main/java/com/sprint/otboo/common/config/SecurityConfig.java
@@ -29,7 +29,10 @@ public class SecurityConfig {
             .csrf(csrf -> csrf
                     .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                     .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler())
-                    .ignoringRequestMatchers("/api/users/*/password") // 비밀번호 변경 확인 테스트를 위해 개발용으로 CSRF 제외
+                    .ignoringRequestMatchers(
+                        "/api/users/*/password",  // 비밀번호 변경
+                                  "/api/users/*/lock"       // 계정 잠금 상태 변경
+                    )
             )
             .sessionManagement(s ->
                     s.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
@@ -45,8 +48,10 @@ public class SecurityConfig {
                 // Actuator
                 .requestMatchers("/actuator/health", "/actuator/info").permitAll()
 
+                // 사용자 관련 API
                 .requestMatchers("/api/users").permitAll()
                 .requestMatchers(HttpMethod.PATCH, "/api/users/*/password").permitAll()
+                .requestMatchers(HttpMethod.PATCH, "/api/users/*/lock").permitAll()
                 .requestMatchers("/api/auth/**").permitAll()
                 .requestMatchers("/h2-console/**").permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/com/sprint/otboo/user/controller/UserController.java
+++ b/src/main/java/com/sprint/otboo/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.sprint.otboo.user.controller;
 import com.sprint.otboo.user.dto.data.UserDto;
 import com.sprint.otboo.user.dto.request.ChangePasswordRequest;
 import com.sprint.otboo.user.dto.request.UserCreateRequest;
+import com.sprint.otboo.user.dto.request.UserLockUpdateRequest;
 import com.sprint.otboo.user.service.UserService;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -36,5 +37,14 @@ public class UserController {
     ) {
         userService.updatePassword(userId, request);
         return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{userId}/lock")
+    public ResponseEntity<UserDto> updateUserLockStatus(
+        @PathVariable UUID userId,
+        @Valid @RequestBody UserLockUpdateRequest request
+    ) {
+        UserDto updatedUser = userService.updateUserLockStatus(userId, request);
+        return ResponseEntity.ok(updatedUser);
     }
 }

--- a/src/main/java/com/sprint/otboo/user/dto/request/UserLockUpdateRequest.java
+++ b/src/main/java/com/sprint/otboo/user/dto/request/UserLockUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.sprint.otboo.user.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserLockUpdateRequest(
+    @NotNull(message = "잠금 상태는 필수 값입니다.")
+    Boolean locked
+) {
+
+}

--- a/src/main/java/com/sprint/otboo/user/entity/User.java
+++ b/src/main/java/com/sprint/otboo/user/entity/User.java
@@ -51,4 +51,8 @@ public class User extends BaseUpdatableEntity {
     public void updatePassword(String password) {
         this.password = password;
     }
+
+    public void updateLockStatus(Boolean lockStatus) {
+        this.locked = lockStatus;
+    }
 }

--- a/src/main/java/com/sprint/otboo/user/service/UserService.java
+++ b/src/main/java/com/sprint/otboo/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.sprint.otboo.user.service;
 import com.sprint.otboo.user.dto.data.UserDto;
 import com.sprint.otboo.user.dto.request.ChangePasswordRequest;
 import com.sprint.otboo.user.dto.request.UserCreateRequest;
+import com.sprint.otboo.user.dto.request.UserLockUpdateRequest;
 import java.util.UUID;
 
 public interface UserService {
@@ -10,4 +11,6 @@ public interface UserService {
     UserDto createUser(UserCreateRequest request);
 
     void updatePassword(UUID userId, ChangePasswordRequest request);
+
+    UserDto updateUserLockStatus(UUID userId, UserLockUpdateRequest request);
 }

--- a/src/main/java/com/sprint/otboo/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/sprint/otboo/user/service/impl/UserServiceImpl.java
@@ -2,9 +2,11 @@ package com.sprint.otboo.user.service.impl;
 
 import com.sprint.otboo.common.exception.CustomException;
 import com.sprint.otboo.common.exception.ErrorCode;
+import com.sprint.otboo.common.exception.user.UserNotFoundException;
 import com.sprint.otboo.user.dto.data.UserDto;
 import com.sprint.otboo.user.dto.request.ChangePasswordRequest;
 import com.sprint.otboo.user.dto.request.UserCreateRequest;
+import com.sprint.otboo.user.dto.request.UserLockUpdateRequest;
 import com.sprint.otboo.user.entity.Role;
 import com.sprint.otboo.user.entity.User;
 import com.sprint.otboo.user.mapper.UserMapper;
@@ -58,6 +60,18 @@ public class UserServiceImpl implements UserService {
 
         String encodedNewPassword = passwordEncoder.encode(request.password());
         user.updatePassword(encodedNewPassword);
+    }
+
+    @Override
+    @Transactional
+    public UserDto updateUserLockStatus(UUID userId, UserLockUpdateRequest request) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        user.updateLockStatus(request.locked());
+        User savedUser = userRepository.save(user);
+
+        return userMapper.toUserDto(savedUser);
     }
 
     private void validateDuplicateEmail(String email) {


### PR DESCRIPTION
## 📌 PR 요약

- 계정 잠금 상태 변경 기능 구현

## ✅ 작업 상세 내용

- [x] 계정 잠금 상태 변경 기능 구현
- [x] 관련 Test 코드 작성
- [x] 리뷰 피드백 반영

## 🧪 테스트 방법

- postman, testcode, jacocoTestReport

<img width="628" height="775" alt="postman" src="https://github.com/user-attachments/assets/37ddec43-1540-48fd-8f9f-ac8a886b85e1" />

<img width="1502" height="298" alt="testcode" src="https://github.com/user-attachments/assets/91d43379-5ab6-4299-b438-dcd397e281ef" />

<img width="1276" height="823" alt="jacoco" src="https://github.com/user-attachments/assets/e1e5e93a-bc8d-472e-99e0-4bcb7c0c3677" />


## 추가 전달 사항
- 부족한 부분이나 이상한 부분 부담없이 피드백 부탁드립니다!