### PR TITLE
[Feat] [SCRUM-48] 알림 목록 조회

### DIFF
--- a/src/main/java/com/sprint/otboo/clothing/event/ClothesAttributeDefCreatedEvent.java
+++ b/src/main/java/com/sprint/otboo/clothing/event/ClothesAttributeDefCreatedEvent.java
@@ -1,0 +1,8 @@
+package com.sprint.otboo.clothing.event;
+
+
+public record ClothesAttributeDefCreatedEvent(
+    String attributeName
+) {
+}
+

--- a/src/main/java/com/sprint/otboo/clothing/service/impl/ClothesAttributeDefServiceImpl.java
+++ b/src/main/java/com/sprint/otboo/clothing/service/impl/ClothesAttributeDefServiceImpl.java
@@ -4,6 +4,7 @@ import com.sprint.otboo.clothing.dto.data.ClothesAttributeDefDto;
 import com.sprint.otboo.clothing.dto.request.ClothesAttributeDefCreateRequest;
 import com.sprint.otboo.clothing.dto.request.ClothesAttributeDefUpdateRequest;
 import com.sprint.otboo.clothing.entity.ClothesAttributeDef;
+import com.sprint.otboo.clothing.event.ClothesAttributeDefCreatedEvent;
 import com.sprint.otboo.clothing.exception.ClothesValidationException;
 import com.sprint.otboo.clothing.mapper.ClothesAttributeDefMapper;
 import com.sprint.otboo.clothing.mapper.ClothesMapper;
@@ -16,6 +17,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
@@ -43,6 +45,7 @@ public class ClothesAttributeDefServiceImpl implements ClothesAttributeDefServic
     private final ClothesAttributeDefRepository clothesAttributeDefRepository;
     private final ClothesAttributeDefMapper clothesAttributeDefMapper;
     private final ClothesMapper clothesMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 새로운 의상 속성 정의 등록
@@ -78,6 +81,9 @@ public class ClothesAttributeDefServiceImpl implements ClothesAttributeDefServic
         // 저장
         ClothesAttributeDef saved = clothesAttributeDefRepository.save(def);
         log.info("의상 속성 정의 등록 완료 : id = {}, name = {}", saved.getId(), saved.getName());
+
+        // 이벤트 발행
+        eventPublisher.publishEvent(new ClothesAttributeDefCreatedEvent(saved.getName()));
 
         // DTO 변환 및 반환
         return clothesMapper.toClothesAttributeDefDto(saved);

--- a/src/main/java/com/sprint/otboo/feed/event/FeedCommentedEvent.java
+++ b/src/main/java/com/sprint/otboo/feed/event/FeedCommentedEvent.java
@@ -1,0 +1,11 @@
+package com.sprint.otboo.feed.event;
+
+import java.util.UUID;
+
+public record FeedCommentedEvent(
+    UUID feedAuthorId,
+    UUID commentedByUserId,
+    UUID commentId
+) {
+
+}

--- a/src/main/java/com/sprint/otboo/feed/event/FeedLikedEvent.java
+++ b/src/main/java/com/sprint/otboo/feed/event/FeedLikedEvent.java
@@ -1,0 +1,10 @@
+package com.sprint.otboo.feed.event;
+
+import java.util.UUID;
+
+public record FeedLikedEvent(
+    UUID feedAuthorId,
+    UUID likedByUserId
+) {
+
+}

--- a/src/main/java/com/sprint/otboo/feed/service/CommentServiceImpl.java
+++ b/src/main/java/com/sprint/otboo/feed/service/CommentServiceImpl.java
@@ -6,6 +6,7 @@ import com.sprint.otboo.common.exception.user.UserNotFoundException;
 import com.sprint.otboo.feed.dto.data.CommentDto;
 import com.sprint.otboo.feed.entity.Comment;
 import com.sprint.otboo.feed.entity.Feed;
+import com.sprint.otboo.feed.event.FeedCommentedEvent;
 import com.sprint.otboo.feed.mapper.CommentMapper;
 import com.sprint.otboo.feed.repository.CommentRepository;
 import com.sprint.otboo.feed.repository.FeedRepository;
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +31,7 @@ public class CommentServiceImpl implements CommentService {
     private final CommentMapper commentMapper;
     private final UserRepository userRepository;
     private final FeedRepository feedRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -49,6 +52,12 @@ public class CommentServiceImpl implements CommentService {
 
         Comment saved = commentRepository.save(entity);
         log.debug("[CommentServiceImpl] 댓글 생성 완료: commentId={}", saved.getId());
+
+        eventPublisher.publishEvent(new FeedCommentedEvent(
+            feed.getAuthor().getId(),
+            author.getId(),
+            saved.getId()
+        ));
 
         return commentMapper.toDto(saved);
     }

--- a/src/main/java/com/sprint/otboo/feed/service/LikeServiceImpl.java
+++ b/src/main/java/com/sprint/otboo/feed/service/LikeServiceImpl.java
@@ -4,6 +4,7 @@ import com.sprint.otboo.common.exception.feed.FeedNotFoundException;
 import com.sprint.otboo.common.exception.user.UserNotFoundException;
 import com.sprint.otboo.feed.entity.Feed;
 import com.sprint.otboo.feed.entity.FeedLike;
+import com.sprint.otboo.feed.event.FeedLikedEvent;
 import com.sprint.otboo.feed.repository.FeedLikeRepository;
 import com.sprint.otboo.feed.repository.FeedRepository;
 import com.sprint.otboo.user.entity.User;
@@ -11,6 +12,7 @@ import com.sprint.otboo.user.repository.UserRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +24,7 @@ public class LikeServiceImpl implements LikeService {
     private final FeedRepository feedRepository;
     private final UserRepository userRepository;
     private final FeedLikeRepository feedLikeRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     @Override
@@ -40,6 +43,8 @@ public class LikeServiceImpl implements LikeService {
         }
         feedLikeRepository.save(FeedLike.builder().feed(feed).user(user).build());
         feed.increaseLikeCount();
+
+        eventPublisher.publishEvent(new FeedLikedEvent(feed.getAuthor().getId(), user.getId()));
 
         log.debug("[LikeServiceImpl] 좋아요 등록 완료: feedId={}, userId={}, likeCount={}",
             feedId, userId, feed.getLikeCount());

--- a/src/main/java/com/sprint/otboo/notification/controller/NotificationController.java
+++ b/src/main/java/com/sprint/otboo/notification/controller/NotificationController.java
@@ -1,5 +1,31 @@
 package com.sprint.otboo.notification.controller;
 
+import com.sprint.otboo.auth.jwt.CustomUserDetails;
+import com.sprint.otboo.common.dto.CursorPageResponse;
+import com.sprint.otboo.notification.dto.request.NotificationQueryParams;
+import com.sprint.otboo.notification.dto.response.NotificationDto;
+import com.sprint.otboo.notification.service.NotificationService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
 public class NotificationController {
 
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public CursorPageResponse<NotificationDto> listNotifications(
+        @AuthenticationPrincipal CustomUserDetails principal,
+        @Valid NotificationQueryParams query
+    ) {
+        UUID receiverId = principal.getUserId();
+        return notificationService.getNotifications(receiverId, query);
+    }
 }

--- a/src/main/java/com/sprint/otboo/notification/dto/request/NotificationQueryParams.java
+++ b/src/main/java/com/sprint/otboo/notification/dto/request/NotificationQueryParams.java
@@ -2,6 +2,8 @@ package com.sprint.otboo.notification.dto.request;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Positive;
+import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 
 public record NotificationQueryParams(
@@ -9,5 +11,17 @@ public record NotificationQueryParams(
     UUID idAfter,
     @Positive @Max(50) int limit
 ) {
+    public Instant parsedCursor() {
+        return Optional.ofNullable(cursor)
+            .filter(s -> !s.isBlank())
+            .map(Instant::parse)
+            .orElse(null);
+    }
 
+    /**
+     * 다음 페이지 여부 판별용
+     * */
+    public int fetchSize() {
+        return Math.min(limit + 1, 51);
+    }
 }

--- a/src/main/java/com/sprint/otboo/notification/dto/request/NotificationQueryParams.java
+++ b/src/main/java/com/sprint/otboo/notification/dto/request/NotificationQueryParams.java
@@ -1,0 +1,13 @@
+package com.sprint.otboo.notification.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Positive;
+import java.util.UUID;
+
+public record NotificationQueryParams(
+    String cursor,
+    UUID idAfter,
+    @Positive @Max(50) int limit
+) {
+
+}

--- a/src/main/java/com/sprint/otboo/notification/dto/response/NotificationDto.java
+++ b/src/main/java/com/sprint/otboo/notification/dto/response/NotificationDto.java
@@ -1,0 +1,16 @@
+package com.sprint.otboo.notification.dto.response;
+
+import com.sprint.otboo.notification.entity.NotificationLevel;
+import java.time.Instant;
+import java.util.UUID;
+
+public record NotificationDto(
+    UUID id,
+    Instant createdAt,
+    UUID receiverId,
+    String title,
+    String content,
+    NotificationLevel level
+) {
+
+}

--- a/src/main/java/com/sprint/otboo/notification/entity/Notification.java
+++ b/src/main/java/com/sprint/otboo/notification/entity/Notification.java
@@ -29,7 +29,7 @@ public class Notification extends BaseEntity {
         nullable = false,
         foreignKey = @ForeignKey(name = "fk_notifications_receiver")
     )
-    private User user;
+    private User receiver;
 
     @Column(name = "title", nullable = false, length = 50)
     private String title;

--- a/src/main/java/com/sprint/otboo/notification/entity/Notification.java
+++ b/src/main/java/com/sprint/otboo/notification/entity/Notification.java
@@ -1,5 +1,43 @@
 package com.sprint.otboo.notification.entity;
 
-public class Notification {
+import com.sprint.otboo.common.base.BaseEntity;
+import com.sprint.otboo.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
+@Entity
+@Table(name = "notifications")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+        name = "receiver_id",
+        nullable = false,
+        foreignKey = @ForeignKey(name = "fk_notifications_receiver")
+    )
+    private User user;
+
+    @Column(name = "title", nullable = false, length = 50)
+    private String title;
+
+    @Column(name = "content", nullable = false, length = 100)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "level", nullable = false, length = 10)
+    private NotificationLevel level;
 }

--- a/src/main/java/com/sprint/otboo/notification/entity/NotificationLevel.java
+++ b/src/main/java/com/sprint/otboo/notification/entity/NotificationLevel.java
@@ -1,0 +1,7 @@
+package com.sprint.otboo.notification.entity;
+
+public enum NotificationLevel {
+    INFO,
+    WARNING,
+    ERROR
+}

--- a/src/main/java/com/sprint/otboo/notification/listener/NotificationListener.java
+++ b/src/main/java/com/sprint/otboo/notification/listener/NotificationListener.java
@@ -1,7 +1,13 @@
 package com.sprint.otboo.notification.listener;
 
+import com.sprint.otboo.clothing.event.ClothesAttributeDefCreatedEvent;
+import com.sprint.otboo.feed.event.FeedCommentedEvent;
+import com.sprint.otboo.feed.event.FeedLikedEvent;
 import com.sprint.otboo.notification.service.NotificationService;
+import com.sprint.otboo.user.entity.Role;
+import com.sprint.otboo.user.entity.User;
 import com.sprint.otboo.user.event.UserRoleChangedEvent;
+import com.sprint.otboo.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -14,6 +20,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class NotificationListener {
 
     private final NotificationService notificationService;
+    private final UserRepository userRepository;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleUserRoleChanged(UserRoleChangedEvent event) {
@@ -21,5 +28,20 @@ public class NotificationListener {
             event.userId(), event.newRole());
 
         notificationService.notifyRoleChanged(event.userId(), event.newRole());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleClothesAttributeCreated(ClothesAttributeDefCreatedEvent event) {
+        notificationService.notifyClothesAttributeCreatedForAllUsers(event.attributeName());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFeedLiked(FeedLikedEvent event) {
+        notificationService.notifyFeedLiked(event.feedAuthorId(), event.likedByUserId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFeedCommented(FeedCommentedEvent event) {
+        notificationService.notifyFeedCommented(event.feedAuthorId(), event.commentedByUserId());
     }
 }

--- a/src/main/java/com/sprint/otboo/notification/listener/NotificationListener.java
+++ b/src/main/java/com/sprint/otboo/notification/listener/NotificationListener.java
@@ -1,0 +1,25 @@
+package com.sprint.otboo.notification.listener;
+
+import com.sprint.otboo.notification.service.NotificationService;
+import com.sprint.otboo.user.event.UserRoleChangedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationListener {
+
+    private final NotificationService notificationService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleUserRoleChanged(UserRoleChangedEvent event) {
+        log.debug("[NotificationListener] handleUserRoleChanged: userId={}, newRole={}",
+            event.userId(), event.newRole());
+
+        notificationService.notifyRoleChanged(event.userId(), event.newRole());
+    }
+}

--- a/src/main/java/com/sprint/otboo/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/sprint/otboo/notification/mapper/NotificationMapper.java
@@ -1,5 +1,13 @@
 package com.sprint.otboo.notification.mapper;
 
-public class NotificationMapper {
+import com.sprint.otboo.notification.dto.response.NotificationDto;
+import com.sprint.otboo.notification.entity.Notification;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
+@Mapper(componentModel = "spring")
+public interface NotificationMapper {
+
+    @Mapping(source = "receiver.id", target = "receiverId")
+    NotificationDto toDto(Notification notification);
 }

--- a/src/main/java/com/sprint/otboo/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sprint/otboo/notification/repository/NotificationRepository.java
@@ -5,5 +5,5 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID>, NotificationRepositoryCustom {
-
+    long countByReceiverId(UUID receiverId);
 }

--- a/src/main/java/com/sprint/otboo/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sprint/otboo/notification/repository/NotificationRepository.java
@@ -1,5 +1,9 @@
 package com.sprint.otboo.notification.repository;
 
-public class NotificationRepository {
+import com.sprint.otboo.notification.entity.Notification;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID>, NotificationRepositoryCustom {
 
 }

--- a/src/main/java/com/sprint/otboo/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/sprint/otboo/notification/repository/NotificationRepositoryCustom.java
@@ -1,9 +1,10 @@
 package com.sprint.otboo.notification.repository;
 
 import com.sprint.otboo.notification.entity.Notification;
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.data.domain.Slice;
 
 public interface NotificationRepositoryCustom {
-    Slice<Notification> findByReceiverWithCursor(UUID receiverId, String cursor, UUID idAfter, int size);
+    Slice<Notification> findByReceiverWithCursor(UUID receiver, Instant cursor, UUID idAfter, int size);
 }

--- a/src/main/java/com/sprint/otboo/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/sprint/otboo/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.sprint.otboo.notification.repository;
+
+import com.sprint.otboo.notification.entity.Notification;
+import java.util.UUID;
+import org.springframework.data.domain.Slice;
+
+public interface NotificationRepositoryCustom {
+    Slice<Notification> findByReceiverWithCursor(UUID receiverId, String cursor, UUID idAfter, int size);
+}

--- a/src/main/java/com/sprint/otboo/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/com/sprint/otboo/notification/repository/NotificationRepositoryImpl.java
@@ -1,0 +1,78 @@
+package com.sprint.otboo.notification.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.otboo.notification.entity.Notification;
+import com.sprint.otboo.notification.entity.QNotification;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Notification> findByReceiverWithCursor(UUID receiverId, String cursor, UUID idAfter, int size) {
+        QNotification notification = QNotification.notification;
+
+        List<Notification> results = queryFactory
+            .selectFrom(notification)
+            .where(
+                notification.receiver.id.eq(receiverId),
+                cursorPredicate(notification, parseCursor(cursor), idAfter)
+            )
+            .orderBy(notification.createdAt.desc(), notification.id.desc())
+            .limit(size + 1L)
+            .fetch();
+
+        boolean hasNext = results.size() > size;
+        if (hasNext) {
+            results = results.subList(0, size);
+        }
+
+        Pageable pageable = PageRequest.of(
+            0,
+            size,
+            Sort.by(Sort.Direction.DESC, "createdAt")
+                .and(Sort.by(Sort.Direction.DESC, "id"))
+        );
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+
+    private BooleanExpression cursorPredicate(QNotification notification, Instant cursorInstant, UUID idAfter) {
+        if (cursorInstant == null && idAfter == null) {
+            return null;
+        }
+        BooleanExpression predicate = null;
+        if (cursorInstant != null) {
+            predicate = notification.createdAt.lt(cursorInstant);
+            if (idAfter != null) {
+                predicate = predicate.or(
+                    notification.createdAt.eq(cursorInstant)
+                        .and(notification.id.lt(idAfter))
+                );
+            }
+        } else if (idAfter != null) {
+            predicate = notification.id.lt(idAfter);
+        }
+        return predicate;
+    }
+
+    private Instant parseCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+        return Instant.parse(cursor);
+    }
+}

--- a/src/main/java/com/sprint/otboo/notification/service/NotificationService.java
+++ b/src/main/java/com/sprint/otboo/notification/service/NotificationService.java
@@ -3,9 +3,12 @@ package com.sprint.otboo.notification.service;
 import com.sprint.otboo.common.dto.CursorPageResponse;
 import com.sprint.otboo.notification.dto.request.NotificationQueryParams;
 import com.sprint.otboo.notification.dto.response.NotificationDto;
+import com.sprint.otboo.user.entity.Role;
 import java.util.UUID;
 
 public interface NotificationService {
 
     CursorPageResponse<NotificationDto> getNotifications(UUID receiverId, NotificationQueryParams query);
+
+    NotificationDto notifyRoleChanged(UUID receiverId, Role newRole);
 }

--- a/src/main/java/com/sprint/otboo/notification/service/NotificationService.java
+++ b/src/main/java/com/sprint/otboo/notification/service/NotificationService.java
@@ -1,5 +1,11 @@
 package com.sprint.otboo.notification.service;
 
-public class NotificationService {
+import com.sprint.otboo.common.dto.CursorPageResponse;
+import com.sprint.otboo.notification.dto.request.NotificationQueryParams;
+import com.sprint.otboo.notification.dto.response.NotificationDto;
+import java.util.UUID;
 
+public interface NotificationService {
+
+    CursorPageResponse<NotificationDto> getNotifications(UUID receiverId, NotificationQueryParams query);
 }

--- a/src/main/java/com/sprint/otboo/notification/service/NotificationService.java
+++ b/src/main/java/com/sprint/otboo/notification/service/NotificationService.java
@@ -11,4 +11,10 @@ public interface NotificationService {
     CursorPageResponse<NotificationDto> getNotifications(UUID receiverId, NotificationQueryParams query);
 
     NotificationDto notifyRoleChanged(UUID receiverId, Role newRole);
+
+    void notifyClothesAttributeCreatedForAllUsers(String attributeName);
+
+    NotificationDto notifyFeedLiked(UUID feedAuthorId, UUID likedByUserId);
+
+    NotificationDto notifyFeedCommented(UUID feedAuthorId, UUID commentedByUserId);
 }

--- a/src/main/java/com/sprint/otboo/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/otboo/notification/service/impl/NotificationServiceImpl.java
@@ -1,0 +1,52 @@
+package com.sprint.otboo.notification.service.impl;
+
+import com.sprint.otboo.common.dto.CursorPageResponse;
+import com.sprint.otboo.notification.dto.request.NotificationQueryParams;
+import com.sprint.otboo.notification.dto.response.NotificationDto;
+import com.sprint.otboo.notification.mapper.NotificationMapper;
+import com.sprint.otboo.notification.repository.NotificationRepository;
+import com.sprint.otboo.notification.service.NotificationService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final NotificationMapper notificationMapper;
+
+    @Override
+    public CursorPageResponse<NotificationDto> getNotifications(UUID receiverId, NotificationQueryParams query) {
+        var slice = notificationRepository.findByReceiverWithCursor(
+            receiverId,
+            query.cursor(),
+            query.idAfter(),
+            query.limit()
+        );
+
+        List<NotificationDto> data = slice.getContent()
+            .stream()
+            .map(notificationMapper::toDto)
+            .toList();
+
+        NotificationDto last = slice.hasNext() && !data.isEmpty()
+            ? data.get(data.size() - 1)
+            : null;
+
+        return new CursorPageResponse<>(
+            data,
+            last != null ? last.createdAt().toString() : null,
+            last != null ? last.id().toString() : null,
+            slice.hasNext(),
+            data.size(),
+            "createdAt",
+            "DESCENDING"
+        );
+    }
+
+}

--- a/src/main/java/com/sprint/otboo/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/otboo/notification/service/impl/NotificationServiceImpl.java
@@ -86,7 +86,7 @@ public class NotificationServiceImpl implements NotificationService {
                 Notification.builder()
                     .receiver(receiver)
                     .title("새 의상 속성이 등록되었습니다.")
-                    .content("%s 속성이 추가되었습니다.".formatted(attributeName))
+                    .content("내 의상에 [%s] 속성을 추가해보세요.".formatted(attributeName))
                     .level(NotificationLevel.INFO)
                     .build()
             );

--- a/src/main/java/com/sprint/otboo/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/otboo/notification/service/impl/NotificationServiceImpl.java
@@ -66,7 +66,7 @@ public class NotificationServiceImpl implements NotificationService {
         Notification notification = Notification.builder()
             .receiver(receiver)
             .title("권한 변경")
-            .content("Your role is now %s.".formatted(newRole.name()))
+            .content("변경된 권한은 %s 입니다.".formatted(newRole.name()))
             .level(NotificationLevel.INFO)
             .build();
 

--- a/src/main/java/com/sprint/otboo/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/otboo/notification/service/impl/NotificationServiceImpl.java
@@ -48,12 +48,14 @@ public class NotificationServiceImpl implements NotificationService {
             ? data.get(data.size() - 1)
             : null;
 
+        long totalCount = notificationRepository.countByReceiverId(receiverId);
+
         return new CursorPageResponse<>(
             data,
             last != null ? last.createdAt().toString() : null,
             last != null ? last.id().toString() : null,
             slice.hasNext(),
-            data.size(),
+            totalCount,
             "createdAt",
             "DESCENDING"
         );

--- a/src/main/java/com/sprint/otboo/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/otboo/notification/service/impl/NotificationServiceImpl.java
@@ -24,9 +24,9 @@ public class NotificationServiceImpl implements NotificationService {
     public CursorPageResponse<NotificationDto> getNotifications(UUID receiverId, NotificationQueryParams query) {
         var slice = notificationRepository.findByReceiverWithCursor(
             receiverId,
-            query.cursor(),
+            query.parsedCursor(),
             query.idAfter(),
-            query.limit()
+            query.fetchSize()
         );
 
         List<NotificationDto> data = slice.getContent()

--- a/src/main/java/com/sprint/otboo/user/entity/User.java
+++ b/src/main/java/com/sprint/otboo/user/entity/User.java
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
-import java.time.Instant;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/sprint/otboo/user/event/UserRoleChangedEvent.java
+++ b/src/main/java/com/sprint/otboo/user/event/UserRoleChangedEvent.java
@@ -1,0 +1,12 @@
+package com.sprint.otboo.user.event;
+
+import com.sprint.otboo.user.entity.Role;
+import com.sprint.otboo.user.entity.User;
+
+public record UserRoleChangedEvent(
+    User user,
+    Role oldRole,
+    Role newRole
+) {
+
+}

--- a/src/main/java/com/sprint/otboo/user/event/UserRoleChangedEvent.java
+++ b/src/main/java/com/sprint/otboo/user/event/UserRoleChangedEvent.java
@@ -1,12 +1,12 @@
 package com.sprint.otboo.user.event;
 
 import com.sprint.otboo.user.entity.Role;
-import com.sprint.otboo.user.entity.User;
+import java.util.UUID;
 
 public record UserRoleChangedEvent(
-    User user,
-    Role oldRole,
+    UUID userId,
+    Role previousRole,
     Role newRole
 ) {
-
 }
+

--- a/src/main/java/com/sprint/otboo/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/sprint/otboo/user/service/impl/UserServiceImpl.java
@@ -15,6 +15,7 @@ import com.sprint.otboo.user.entity.Gender;
 import com.sprint.otboo.user.entity.Role;
 import com.sprint.otboo.user.entity.User;
 import com.sprint.otboo.user.entity.UserProfile;
+import com.sprint.otboo.user.event.UserRoleChangedEvent;
 import com.sprint.otboo.user.mapper.UserMapper;
 import com.sprint.otboo.user.repository.UserProfileRepository;
 import com.sprint.otboo.user.repository.UserRepository;
@@ -34,6 +35,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -55,6 +57,7 @@ public class UserServiceImpl implements UserService {
     private final WeatherLocationQueryService weatherLocationQueryService;
     private final AsyncProfileImageUploader asyncProfileImageUploader;
     private final RetryTemplate profileImageStorageRetryTemplate;
+    private final ApplicationEventPublisher eventPublisher;
 
     public UserServiceImpl(
         UserRepository userRepository,
@@ -65,7 +68,8 @@ public class UserServiceImpl implements UserService {
         @Qualifier("profileImageStorageService") FileStorageService fileStorageService,
         WeatherLocationQueryService weatherLocationQueryService,
         AsyncProfileImageUploader asyncProfileImageUploader,
-        @Qualifier("profileImageStorageRetryTemplate") RetryTemplate profileImageStorageRetryTemplate
+        @Qualifier("profileImageStorageRetryTemplate") RetryTemplate profileImageStorageRetryTemplate,
+        ApplicationEventPublisher eventPublisher
     ) {
         this.userRepository = userRepository;
         this.userProfileRepository = userProfileRepository;
@@ -76,6 +80,7 @@ public class UserServiceImpl implements UserService {
         this.weatherLocationQueryService = weatherLocationQueryService;
         this.asyncProfileImageUploader = asyncProfileImageUploader;
         this.profileImageStorageRetryTemplate = profileImageStorageRetryTemplate;
+        this.eventPublisher = eventPublisher;
     }
 
     @Override
@@ -144,10 +149,12 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
+        Role previousRole = user.getRole();
         Role newRole = Role.valueOf(request.role());
         user.updateRole(newRole);
         User savedUser = userRepository.save(user);
 
+        eventPublisher.publishEvent(new UserRoleChangedEvent(savedUser, previousRole, newRole));
 
         log.debug("[UserServiceImpl] 권한 수정 요청: userId = {} , role = {} ", userId, newRole);
         return userMapper.toUserDto(savedUser);

--- a/src/main/java/com/sprint/otboo/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/sprint/otboo/user/service/impl/UserServiceImpl.java
@@ -154,7 +154,10 @@ public class UserServiceImpl implements UserService {
         user.updateRole(newRole);
         User savedUser = userRepository.save(user);
 
-        eventPublisher.publishEvent(new UserRoleChangedEvent(savedUser, previousRole, newRole));
+        log.debug("[UserServiceImpl] publish UserRoleChangedEvent: userId={}, previousRole={}, newRole={}",
+            savedUser.getId(), previousRole, newRole);
+
+        eventPublisher.publishEvent(new UserRoleChangedEvent(savedUser.getId(), previousRole, newRole));
 
         log.debug("[UserServiceImpl] 권한 수정 요청: userId = {} , role = {} ", userId, newRole);
         return userMapper.toUserDto(savedUser);

--- a/src/test/java/com/sprint/otboo/feed/service/LikeServiceTest.java
+++ b/src/test/java/com/sprint/otboo/feed/service/LikeServiceTest.java
@@ -10,6 +10,7 @@ import com.sprint.otboo.common.exception.feed.FeedNotFoundException;
 import com.sprint.otboo.common.exception.user.UserNotFoundException;
 import com.sprint.otboo.feed.entity.Feed;
 import com.sprint.otboo.feed.entity.FeedLike;
+import com.sprint.otboo.feed.event.FeedLikedEvent;
 import com.sprint.otboo.feed.repository.FeedLikeRepository;
 import com.sprint.otboo.feed.repository.FeedRepository;
 import com.sprint.otboo.user.entity.User;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("LikeService 테스트")
@@ -35,6 +37,8 @@ public class LikeServiceTest {
     private FeedRepository feedRepository;
     @Mock
     private FeedLikeRepository feedLikeRepository;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
     @InjectMocks
     private LikeServiceImpl likeService;
 
@@ -75,6 +79,7 @@ public class LikeServiceTest {
             then(feedRepository).shouldHaveNoMoreInteractions();
             then(userRepository).should().findById(userId);
             then(userRepository).shouldHaveNoMoreInteractions();
+            then(eventPublisher).should().publishEvent(any(FeedLikedEvent.class));
         }
 
         @Test

--- a/src/test/java/com/sprint/otboo/fixture/FeedFixture.java
+++ b/src/test/java/com/sprint/otboo/fixture/FeedFixture.java
@@ -199,4 +199,17 @@ public class FeedFixture {
             .updatedAt(createdAt)
             .build();
     }
+
+    public static Feed createWithIdAndAuthor(UUID feedId, User author, Weather weather) {
+        return Feed.builder()
+            .id(feedId)
+            .author(author)
+            .weather(weather)
+            .content("기본 컨텐츠")
+            .likeCount(0L)
+            .commentCount(0)
+            .createdAt(Instant.now())
+            .updatedAt(Instant.now())
+            .build();
+    }
 }

--- a/src/test/java/com/sprint/otboo/fixture/WeatherFixture.java
+++ b/src/test/java/com/sprint/otboo/fixture/WeatherFixture.java
@@ -5,6 +5,7 @@ import com.sprint.otboo.weather.entity.SkyStatus;
 import com.sprint.otboo.weather.entity.Weather;
 import com.sprint.otboo.weather.entity.WeatherLocation;
 import com.sprint.otboo.weather.entity.WindStrength;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -65,5 +66,16 @@ public class WeatherFixture {
             .skyStatus(skyStatus)
             .type(precipType)
             .build();
+    }
+
+    public static Weather createWeatherWithDefaultLocation() {
+        WeatherLocation location = WeatherLocation.builder()
+            .id(UUID.randomUUID())
+            .latitude(BigDecimal.valueOf(37.5253652))
+            .longitude(BigDecimal.valueOf(126.6849254))
+            .locationNames("인천광역시 서구 가정2동")
+            .build();
+
+        return createWeatherWithDefault(location);
     }
 }

--- a/src/test/java/com/sprint/otboo/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/sprint/otboo/notification/controller/NotificationControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.sprint.otboo.auth.jwt.CustomUserDetails;
+import com.sprint.otboo.auth.jwt.JwtRegistry;
 import com.sprint.otboo.auth.jwt.TokenProvider;
 import com.sprint.otboo.common.dto.CursorPageResponse;
 import com.sprint.otboo.notification.dto.request.NotificationQueryParams;
@@ -42,6 +43,9 @@ public class NotificationControllerTest {
 
     @MockitoBean
     private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private JwtRegistry jwtRegistry;
 
     private CustomUserDetails userPrincipal(UUID id) {
         UserDto dto = new UserDto(

--- a/src/test/java/com/sprint/otboo/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/sprint/otboo/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,108 @@
+package com.sprint.otboo.notification.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.sprint.otboo.auth.jwt.CustomUserDetails;
+import com.sprint.otboo.auth.jwt.TokenProvider;
+import com.sprint.otboo.common.dto.CursorPageResponse;
+import com.sprint.otboo.notification.dto.request.NotificationQueryParams;
+import com.sprint.otboo.notification.dto.response.NotificationDto;
+import com.sprint.otboo.notification.entity.NotificationLevel;
+import com.sprint.otboo.notification.service.NotificationService;
+import com.sprint.otboo.user.dto.data.UserDto;
+import com.sprint.otboo.user.entity.LoginType;
+import com.sprint.otboo.user.entity.Role;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.h2.engine.User;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(NotificationController.class)
+@DisplayName("NotificationController 테스트")
+public class NotificationControllerTest {
+
+    @AutoClose
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NotificationService notificationService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    private CustomUserDetails userPrincipal(UUID id) {
+        UserDto dto = new UserDto(
+            id,
+            Instant.now(),
+            "test@test.com",
+            "testUser",
+            Role.USER,
+            LoginType.GENERAL,
+            false
+        );
+        return CustomUserDetails.builder()
+            .userDto(dto)
+            .password("encodedPassword")
+            .build();
+    }
+
+    private NotificationDto notificationDto(UUID receiverId) {
+        return new NotificationDto(
+            UUID.randomUUID(),
+            Instant.now(),
+            receiverId,
+            "테스트 알림",
+            "테스트 알림입니다.",
+            NotificationLevel.INFO
+        );
+    }
+    @Test
+    void 인증_사용자가_알림_목록을_조회하여_커서_기반_응답_반환() throws Exception {
+        // given
+        UUID receiverId = UUID.randomUUID();
+        CustomUserDetails principal = userPrincipal(receiverId);
+
+        NotificationDto dto = notificationDto(receiverId);
+        CursorPageResponse<NotificationDto> response = new CursorPageResponse<>(
+            List.of(dto),
+            "2025-09-24T10:00:00Z",
+            UUID.randomUUID().toString(),
+            true,
+            42L,
+            "createdAt",
+            "DESCENDING"
+        );
+        given(notificationService.getNotifications(any(), any()))
+            .willReturn(response);
+
+        // when
+        mockMvc.perform(get("/api/notificaitons")
+            .param("limit","10")
+            .with(user(principal)))
+            // then
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data[0].id").value(dto.id().toString()))
+            .andExpect(jsonPath("$.data[0].level").value(dto.level().name()))
+            .andExpect(jsonPath("$.hasNext").value(true))
+            .andExpect(jsonPath("$.sortBy").value("createdAt"));
+
+        ArgumentCaptor<NotificationQueryParams> captor = ArgumentCaptor.forClass(NotificationQueryParams.class);
+        then(notificationService).should().getNotifications(receiverId, captor.capture());
+        NotificationQueryParams captured = captor.getValue();
+        assertThat(captured.limit()).isEqualTo(10);
+    }
+}

--- a/src/test/java/com/sprint/otboo/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/sprint/otboo/notification/controller/NotificationControllerTest.java
@@ -22,11 +22,10 @@ import com.sprint.otboo.user.entity.Role;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-import org.h2.engine.User;
-import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -35,7 +34,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @DisplayName("NotificationController 테스트")
 public class NotificationControllerTest {
 
-    @AutoClose
+    @Autowired
     private MockMvc mockMvc;
 
     @MockitoBean
@@ -90,7 +89,7 @@ public class NotificationControllerTest {
             .willReturn(response);
 
         // when
-        mockMvc.perform(get("/api/notificaitons")
+        mockMvc.perform(get("/api/notifications")
             .param("limit","10")
             .with(user(principal)))
             // then
@@ -100,9 +99,12 @@ public class NotificationControllerTest {
             .andExpect(jsonPath("$.hasNext").value(true))
             .andExpect(jsonPath("$.sortBy").value("createdAt"));
 
-        ArgumentCaptor<NotificationQueryParams> captor = ArgumentCaptor.forClass(NotificationQueryParams.class);
-        then(notificationService).should().getNotifications(receiverId, captor.capture());
-        NotificationQueryParams captured = captor.getValue();
-        assertThat(captured.limit()).isEqualTo(10);
+        ArgumentCaptor<UUID> idCaptor = ArgumentCaptor.forClass(UUID.class);
+        ArgumentCaptor<NotificationQueryParams> paramCaptor = ArgumentCaptor.forClass(NotificationQueryParams.class);
+
+        then(notificationService).should().getNotifications(idCaptor.capture(), paramCaptor.capture());
+
+        assertThat(idCaptor.getValue()).isEqualTo(receiverId);
+        assertThat(paramCaptor.getValue().limit()).isEqualTo(10);
     }
 }

--- a/src/test/java/com/sprint/otboo/notification/listener/NotificationListenerTest.java
+++ b/src/test/java/com/sprint/otboo/notification/listener/NotificationListenerTest.java
@@ -2,6 +2,9 @@ package com.sprint.otboo.notification.listener;
 
 import static org.mockito.BDDMockito.then;
 
+import com.sprint.otboo.clothing.event.ClothesAttributeDefCreatedEvent;
+import com.sprint.otboo.feed.event.FeedCommentedEvent;
+import com.sprint.otboo.feed.event.FeedLikedEvent;
 import com.sprint.otboo.notification.service.NotificationService;
 import com.sprint.otboo.user.entity.Role;
 import com.sprint.otboo.user.event.UserRoleChangedEvent;
@@ -34,5 +37,39 @@ public class NotificationListenerTest {
 
         // then
         then(notificationService).should().notifyRoleChanged(userId, Role.ADMIN);
+    }
+
+    @Test
+    void 의상_속성_추가_이벤트를_받으면_전체_알림을_생성한다() {
+        ClothesAttributeDefCreatedEvent event = new ClothesAttributeDefCreatedEvent("기능성");
+
+        notificationListener.handleClothesAttributeCreated(event);
+
+        then(notificationService).should()
+            .notifyClothesAttributeCreatedForAllUsers("기능성");
+    }
+
+    @Test
+    void 피드_좋아요_이벤트를_받으면_작성자에게_알림을_생성한다() {
+        UUID authorId = UUID.randomUUID();
+        UUID likerId = UUID.randomUUID();
+        FeedLikedEvent event = new FeedLikedEvent(authorId, likerId);
+
+        notificationListener.handleFeedLiked(event);
+
+        then(notificationService).should().notifyFeedLiked(authorId, likerId);
+    }
+
+    @Test
+    void 피드_댓글_이벤트를_받으면_작성자에게_알림을_생성한다() {
+        UUID authorId = UUID.randomUUID();
+        UUID commenterId = UUID.randomUUID();
+        UUID commentId = UUID.randomUUID();
+        FeedCommentedEvent event = new FeedCommentedEvent(authorId, commenterId, commentId);
+
+        notificationListener.handleFeedCommented(event);
+
+        then(notificationService).should()
+            .notifyFeedCommented(authorId, commenterId);
     }
 }

--- a/src/test/java/com/sprint/otboo/notification/listener/NotificationListenerTest.java
+++ b/src/test/java/com/sprint/otboo/notification/listener/NotificationListenerTest.java
@@ -1,0 +1,38 @@
+package com.sprint.otboo.notification.listener;
+
+import static org.mockito.BDDMockito.then;
+
+import com.sprint.otboo.notification.service.NotificationService;
+import com.sprint.otboo.user.entity.Role;
+import com.sprint.otboo.user.event.UserRoleChangedEvent;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotificationListener 테스트")
+public class NotificationListenerTest {
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private NotificationListener notificationListener;
+
+    @Test
+    void 권한_변경_이벤트를_받으면_알림_생성을_위임() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UserRoleChangedEvent event = new UserRoleChangedEvent(userId, Role.USER, Role.ADMIN);
+
+        // when
+        notificationListener.handleUserRoleChanged(event);
+
+        // then
+        then(notificationService).should().notifyRoleChanged(userId, Role.ADMIN);
+    }
+}

--- a/src/test/java/com/sprint/otboo/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/sprint/otboo/notification/repository/NotificationRepositoryTest.java
@@ -63,11 +63,13 @@ public class NotificationRepositoryTest {
     }
 
     @Test
-    void 커서_없이_조회하면_최신순으로_정렬된다() {
+    void 커서_없이_조회하면_최신순으로_정렬() {
+        // given
         User receiver = persistUser();
         Notification n1 = persistNotification(receiver, Instant.parse("2025-09-24T09:00:00Z"));
         Notification n2 = persistNotification(receiver, Instant.parse("2025-09-24T08:00:00Z"));
 
+        // when
         Slice<Notification> slice = notificationRepository.findByReceiverWithCursor(
             receiver.getId(),
             null,
@@ -75,16 +77,19 @@ public class NotificationRepositoryTest {
             3
         );
 
+        // then
         assertThat(slice.getContent()).extracting(Notification::getId).containsExactly(n1.getId(), n2.getId());
         assertThat(slice.hasNext()).isFalse();
     }
 
     @Test
-    void 커서를_이용해_이후_데이터만_조회한다() {
+    void 커서를_이용해_이후_데이터만_조회() {
+        // given
         User receiver = persistUser();
         Notification newer = persistNotification(receiver, Instant.parse("2025-09-24T10:00:00Z"));
         Notification older = persistNotification(receiver, Instant.parse("2025-09-24T09:00:00Z"));
 
+        // when
         Slice<Notification> slice = notificationRepository.findByReceiverWithCursor(
             receiver.getId(),
             newer.getCreatedAt(),
@@ -92,6 +97,7 @@ public class NotificationRepositoryTest {
             3
         );
 
+        // then
         assertThat(slice.getContent()).extracting(Notification::getId).containsExactly(older.getId());
     }
 }

--- a/src/test/java/com/sprint/otboo/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/sprint/otboo/notification/repository/NotificationRepositoryTest.java
@@ -1,0 +1,97 @@
+package com.sprint.otboo.notification.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.otboo.common.config.JpaAuditingConfig;
+import com.sprint.otboo.common.config.QuerydslConfig;
+import com.sprint.otboo.notification.entity.Notification;
+import com.sprint.otboo.notification.entity.NotificationLevel;
+import com.sprint.otboo.user.entity.LoginType;
+import com.sprint.otboo.user.entity.Role;
+import com.sprint.otboo.user.entity.User;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+@Import({QuerydslConfig.class, JpaAuditingConfig.class})
+public class NotificationRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private User persistUser() {
+        User user = User.builder()
+            .username("testUser")
+            .password("encodedPassword")
+            .email("test@test.com")
+            .role(Role.USER)
+            .locked(false)
+            .provider(LoginType.GENERAL)
+            .build();
+
+        return entityManager.persistAndFlush(user);
+    }
+
+    private Notification persistNotification(User receiver, Instant createdAt) {
+        Notification notification = Notification.builder()
+            .receiver(receiver)
+            .title("테스트 알림")
+            .content("테스트 알림입니다.")
+            .level(NotificationLevel.INFO)
+            .build();
+
+        notification = entityManager.persist(notification);
+        entityManager.flush();
+
+        UUID id = notification.getId(); // UUID가 생성된 상태
+        Notification managed = entityManager.find(Notification.class, id);
+        ReflectionTestUtils.setField(managed, "createdAt", createdAt);
+        entityManager.flush();
+
+        return managed;
+    }
+
+    @Test
+    void 커서_없이_조회하면_최신순으로_정렬된다() {
+        User receiver = persistUser();
+        Notification n1 = persistNotification(receiver, Instant.parse("2025-09-24T09:00:00Z"));
+        Notification n2 = persistNotification(receiver, Instant.parse("2025-09-24T08:00:00Z"));
+
+        Slice<Notification> slice = notificationRepository.findByReceiverWithCursor(
+            receiver.getId(),
+            null,
+            null,
+            3
+        );
+
+        assertThat(slice.getContent()).extracting(Notification::getId).containsExactly(n1.getId(), n2.getId());
+        assertThat(slice.hasNext()).isFalse();
+    }
+
+    @Test
+    void 커서를_이용해_이후_데이터만_조회한다() {
+        User receiver = persistUser();
+        Notification newer = persistNotification(receiver, Instant.parse("2025-09-24T10:00:00Z"));
+        Notification older = persistNotification(receiver, Instant.parse("2025-09-24T09:00:00Z"));
+
+        Slice<Notification> slice = notificationRepository.findByReceiverWithCursor(
+            receiver.getId(),
+            newer.getCreatedAt(),
+            newer.getId(),
+            3
+        );
+
+        assertThat(slice.getContent()).extracting(Notification::getId).containsExactly(older.getId());
+    }
+}

--- a/src/test/java/com/sprint/otboo/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/otboo/notification/service/NotificationServiceTest.java
@@ -178,16 +178,16 @@ public class NotificationServiceTest {
         given(userRepository.getReferenceById(receiverId)).willReturn(receiver);
 
         Notification saved = notificationEntityOwnedBy(receiver, NotificationLevel.INFO);
-        given(notificationRepository.save(any(Notification.class))).willReturn(saved);
-
         NotificationDto expectedDto = notificationDto(saved);
+
+        given(notificationRepository.saveAndFlush(any(Notification.class))).willReturn(saved);
         given(notificationMapper.toDto(saved)).willReturn(expectedDto);
 
         // when
         NotificationDto result = notificationService.notifyRoleChanged(receiverId, newRole);
 
         // then
-        then(notificationRepository).should().save(any(Notification.class));
+        then(notificationRepository).should().saveAndFlush(any(Notification.class));
         assertThat(result).isEqualTo(expectedDto);
     }
 }

--- a/src/test/java/com/sprint/otboo/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/otboo/notification/service/NotificationServiceTest.java
@@ -2,14 +2,16 @@ package com.sprint.otboo.notification.service;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.given;
+import static org.mockito.BDDMockito.given;
 
 import com.sprint.otboo.common.dto.CursorPageResponse;
+import com.sprint.otboo.notification.dto.request.NotificationQueryParams;
 import com.sprint.otboo.notification.dto.response.NotificationDto;
 import com.sprint.otboo.notification.entity.Notification;
 import com.sprint.otboo.notification.entity.NotificationLevel;
 import com.sprint.otboo.notification.mapper.NotificationMapper;
 import com.sprint.otboo.notification.repository.NotificationRepository;
+import com.sprint.otboo.notification.service.impl.NotificationServiceImpl;
 import com.sprint.otboo.user.entity.LoginType;
 import com.sprint.otboo.user.entity.Role;
 import com.sprint.otboo.user.entity.User;
@@ -97,12 +99,12 @@ public class NotificationServiceTest {
         NotificationQueryParams query = new NotificationQueryParams(null, null, 20);
 
         Notification entity = notificationEntity(receiverId, NotificationLevel.INFO);
-        Slice<Notification> slice = notificationSlice(List.of(entity), 1, false);
+        Slice<Notification> slice = notificationSlice(List.of(entity), query.limit(), false);
         given(notificationRepository.findByReceiverWithCursor(
             receiverId,
             query.cursor(),
             query.idAfter(),
-            query.limit() + 1
+            query.limit()
         )).willReturn(slice);
 
         NotificationDto expectedDto = notificationDto(entity);

--- a/src/test/java/com/sprint/otboo/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/otboo/notification/service/NotificationServiceTest.java
@@ -102,9 +102,9 @@ public class NotificationServiceTest {
         Slice<Notification> slice = notificationSlice(List.of(entity), query.limit(), false);
         given(notificationRepository.findByReceiverWithCursor(
             receiverId,
-            query.cursor(),
+            query.parsedCursor(),
             query.idAfter(),
-            query.limit()
+            query.fetchSize()
         )).willReturn(slice);
 
         NotificationDto expectedDto = notificationDto(entity);

--- a/src/test/java/com/sprint/otboo/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/otboo/notification/service/NotificationServiceTest.java
@@ -1,6 +1,5 @@
 package com.sprint.otboo.notification.service;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 

--- a/src/test/java/com/sprint/otboo/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/otboo/notification/service/NotificationServiceTest.java
@@ -169,7 +169,7 @@ public class NotificationServiceTest {
     }
 
     @Test
-    void 권한_변경_알림을_저장하고_DTO로_반환한다() {
+    void 권한_변경_알림을_저장하고_DTO로_반환() {
         // given
         UUID receiverId = UUID.randomUUID();
         Role newRole = Role.ADMIN;

--- a/src/test/java/com/sprint/otboo/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/sprint/otboo/notification/service/NotificationServiceTest.java
@@ -1,0 +1,120 @@
+package com.sprint.otboo.notification.service;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.given;
+
+import com.sprint.otboo.common.dto.CursorPageResponse;
+import com.sprint.otboo.notification.dto.response.NotificationDto;
+import com.sprint.otboo.notification.entity.Notification;
+import com.sprint.otboo.notification.entity.NotificationLevel;
+import com.sprint.otboo.notification.mapper.NotificationMapper;
+import com.sprint.otboo.notification.repository.NotificationRepository;
+import com.sprint.otboo.user.entity.LoginType;
+import com.sprint.otboo.user.entity.Role;
+import com.sprint.otboo.user.entity.User;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotificationService 테스트")
+public class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private NotificationMapper notificationMapper;
+
+    @InjectMocks
+    private NotificationServiceImpl notificationService;
+
+    private NotificationQueryParams notificationQuery(String cursor, UUID idAfter, int limit) {
+        return new NotificationQueryParams(cursor, idAfter, limit);
+    }
+
+    private Notification notificationEntity(UUID receiverId, NotificationLevel level) {
+        return Notification.builder()
+            .id(UUID.randomUUID())
+            .createdAt(Instant.now())
+            .receiver(user(receiverId))
+            .title("테스트 알림")
+            .content("알림 내용")
+            .level(level)
+            .build();
+    }
+
+    private NotificationDto notificationDto(Notification entity) {
+        return new NotificationDto(
+            entity.getId(),
+            entity.getCreatedAt(),
+            entity.getReceiver().getId(),
+            entity.getTitle(),
+            entity.getContent(),
+            entity.getLevel()
+        );
+    }
+
+    private Slice<Notification> notificationSlice(List<Notification> content, int requestedSize, boolean hasNext) {
+        PageRequest pageRequest = PageRequest.of(
+            0,
+            requestedSize,
+            Sort.by(Direction.DESC, "createdAt")
+                .and(Sort.by(Direction.DESC, "id"))
+            );
+        return new SliceImpl<>(content, pageRequest, hasNext);
+    }
+
+
+    private User user(UUID id) {
+        return User.builder()
+            .id(id)
+            .createdAt(Instant.now())
+            .username("testUser")
+            .password("encodedPassword")
+            .email("test@test.com")
+            .role(Role.USER)
+            .locked(false)
+            .provider(LoginType.GENERAL)
+            .build();
+    }
+
+    @Test
+    void 알림_목록을_cursor_없이_조회하여_마지막_요소까지_반환() {
+        // given
+        UUID receiverId = UUID.randomUUID();
+        NotificationQueryParams query = new NotificationQueryParams(null, null, 20);
+
+        Notification entity = notificationEntity(receiverId, NotificationLevel.INFO);
+        Slice<Notification> slice = notificationSlice(List.of(entity), 1, false);
+        given(notificationRepository.findByReceiverWithCursor(
+            receiverId,
+            query.cursor(),
+            query.idAfter(),
+            query.limit() + 1
+        )).willReturn(slice);
+
+        NotificationDto expectedDto = notificationDto(entity);
+        given(notificationMapper.toDto(entity)).willReturn(expectedDto);
+
+        // when
+        CursorPageResponse<NotificationDto> actual = notificationService.getNotifications(receiverId, query);
+
+        // then
+        assertThat(actual.data()).containsExactly(expectedDto);
+        assertThat(actual.hasNext()).isFalse();
+        assertThat(actual.nextCursor()).isNull();
+        assertThat(actual.nextIdAfter()).isNull();
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약

- 알림 목록 조회 기능 구현

## ✅ 작업 상세 내용

- [x] 기본적인 Notification Entity, Dto, Mapper 구현
- [x] 알림 목록 조회 기능 구현
- [x] 관련 테스트 작성
- [ ] 리뷰 피드백 반영

## 🧪 테스트 방법

<img width="1438" height="886" alt="알림 조회 기능 구현" src="https://github.com/user-attachments/assets/26c36d1c-8a2e-477d-970f-cf9ee7d4a0b6" />

<img width="1479" height="207" alt="DB" src="https://github.com/user-attachments/assets/0b625bad-2c74-4a73-83c5-0fab8138a9fd" />

<img width="1194" height="890" alt="jacoco" src="https://github.com/user-attachments/assets/b75343b5-54ae-449c-91c5-6683717838bc" />


## 추가 전달 사항
- 기본적인 Notificaiton Entity, Dto, Mapper를 구현하고 알림 목록 조회 기능을 구현했습니다.
- 해당 조회 기능을 보기 위해 일단 요구사항에서 말한 6가지 알림이 오는 case 중에 제가 담당했던 권한 변경에 대해서만 이벤트 발행을 해서 테스트한 결과 알림 조회가 잘 되는 것을 확인하였습니다.
- 리뷰하시다가 이상하거나 궁금하거나 문제가 있을 거 같으시면 부담없이 피드백 부탁드립니다 😄