### PR TITLE
[Feat] [SCRUM-77] 자동 로그아웃

### DIFF
--- a/src/main/java/com/sprint/otboo/auth/jwt/InMemoryJwtRegistry.java
+++ b/src/main/java/com/sprint/otboo/auth/jwt/InMemoryJwtRegistry.java
@@ -72,6 +72,14 @@ public class InMemoryJwtRegistry implements JwtRegistry {
         }
     }
 
+    @Override
+    public void invalidateAll(UUID userId) {
+        Queue<JwtInformation> sessionQueue = activeSessions.remove(userId);
+        if (sessionQueue != null) {
+            sessionQueue.forEach(this::invalidateTokens);
+        }
+    }
+
     private void invalidateTokens(JwtInformation sessionInfo) {
         validAccessTokens.remove(sessionInfo.accessToken());
         validRefreshTokens.remove(sessionInfo.refreshToken());

--- a/src/main/java/com/sprint/otboo/auth/jwt/JwtRegistry.java
+++ b/src/main/java/com/sprint/otboo/auth/jwt/JwtRegistry.java
@@ -1,6 +1,7 @@
 package com.sprint.otboo.auth.jwt;
 
 import com.sprint.otboo.auth.dto.JwtInformation;
+import java.util.UUID;
 
 public interface JwtRegistry {
 
@@ -24,4 +25,10 @@ public interface JwtRegistry {
      * 전달된 Refresh Token에 해당하는 세션을 무효화(로그아웃)
      */
     void invalidate(String refreshToken);
+
+    /**
+     * 특정 사용자의 모든 활성 JWT 세션을 무효화합니다. (계정 잠금/권한 변경 시 호출)
+     * @param userId 무효화할 사용자의 ID
+     */
+    void invalidateAll(UUID userId);
 }

--- a/src/main/java/com/sprint/otboo/auth/oauth/KakaoUserInfo.java
+++ b/src/main/java/com/sprint/otboo/auth/oauth/KakaoUserInfo.java
@@ -34,8 +34,9 @@ public class KakaoUserInfo implements OAuth2UserInfo {
 
         if (email == null) {
             String nickname = getName();
+            String providerId = getProviderUserId();
             if (nickname != null) {
-                email = nickname.replaceAll("\\s+", "") + "@kakao.com";
+                email = nickname.replaceAll("\\s+", "") + "_" + providerId + "@kakao.com";
             }
         }
 

--- a/src/main/java/com/sprint/otboo/user/event/UserLockedEvent.java
+++ b/src/main/java/com/sprint/otboo/user/event/UserLockedEvent.java
@@ -1,0 +1,8 @@
+package com.sprint.otboo.user.event;
+
+import java.util.UUID;
+
+public record UserLockedEvent(
+    UUID userId
+) {
+}

--- a/src/main/java/com/sprint/otboo/user/event/UserStatusEventListener.java
+++ b/src/main/java/com/sprint/otboo/user/event/UserStatusEventListener.java
@@ -1,0 +1,28 @@
+package com.sprint.otboo.user.event;
+
+import com.sprint.otboo.auth.jwt.JwtRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserStatusEventListener {
+
+    private final JwtRegistry jwtRegistry;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleUserLockedEvent(UserLockedEvent event) {
+        log.info("계정 잠금 이벤트 수신. 강제 로그아웃 처리: userId={}", event.userId());
+        jwtRegistry.invalidateAll(event.userId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleUserRoleChangedEvent(UserRoleChangedEvent event) {
+        log.info("권한 변경 이벤트 수신. 강제 로그아웃 처리: userId={}", event.userId());
+        jwtRegistry.invalidateAll(event.userId());
+    }
+}

--- a/src/test/java/com/sprint/otboo/auth/service/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/sprint/otboo/auth/service/CustomOAuth2UserServiceTest.java
@@ -123,7 +123,7 @@ class CustomOAuth2UserServiceTest {
         // then
         assertThat(resultUser).isNotNull();
         UserDto resultUserDto = resultUser.getUserDto();
-        assertThat(resultUserDto.email()).isEqualTo("테스트유저@kakao.com");
+        assertThat(resultUserDto.email()).isEqualTo("테스트유저_123456789@kakao.com");
         assertThat(resultUserDto.name()).isEqualTo("테스트유저");
         assertThat(resultUserDto.role()).isEqualTo(Role.USER);
 

--- a/src/test/java/com/sprint/otboo/user/service/support/UserStatusEventListenerTest.java
+++ b/src/test/java/com/sprint/otboo/user/service/support/UserStatusEventListenerTest.java
@@ -1,0 +1,51 @@
+package com.sprint.otboo.user.service.support;
+
+import static org.mockito.BDDMockito.then;
+
+import com.sprint.otboo.auth.jwt.JwtRegistry;
+import com.sprint.otboo.user.entity.Role;
+import com.sprint.otboo.user.event.UserLockedEvent;
+import com.sprint.otboo.user.event.UserRoleChangedEvent;
+import com.sprint.otboo.user.event.UserStatusEventListener;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserStatusEventListenerTest {
+
+    @Mock
+    private JwtRegistry jwtRegistry;
+
+    @InjectMocks
+    private UserStatusEventListener userStatusEventListener;
+
+    @Test
+    void 계정_잠금_이벤트_처리_테스트() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UserLockedEvent event = new UserLockedEvent(userId);
+
+        // when
+        userStatusEventListener.handleUserLockedEvent(event);
+
+        // then
+        then(jwtRegistry).should().invalidateAll(userId);
+    }
+
+    @Test
+    void 권한_변경_이벤트_처리_테스트() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UserRoleChangedEvent event = new UserRoleChangedEvent(userId, Role.USER, Role.ADMIN);
+
+        // when
+        userStatusEventListener.handleUserRoleChangedEvent(event);
+
+        // then
+        then(jwtRegistry).should().invalidateAll(userId);
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약

-  **권한 관리**: 사용자의 권한을 **`ADMIN`** 또는 **`USER`**로 변경할 수 있습니다. 권한 변경 시 해당 사용자는 **자동으로 로그아웃**됩니다.
- **계정 잠금**: 사용자 계정을 잠글 수 있으며, 잠긴 계정은 로그인할 수 없습니다. 잠긴 계정은 **자동으로 로그아웃**됩니다.
- 참고: 카카오 로그인 API 제약으로 인해 이메일 정보는 가져올 수 없습니다. 
이 경우 `{닉네임}_{회원ID}@kakao.com`과 같은 가상의 이메일 주소를 사용합니다

## ✅ 작업 상세 내용

- [x] 주요 기능 구현
- [ ] 관련 API 변경
- [x] 기타 리팩터링

## 🧪 테스트 방법

- localhost:8080, db, junit

## 추가 전달 사항
참고) 개인개발레포트/자동 로그아웃 https://www.notion.so/ohgiraffers/27e649136c1180669f48f62f26142de8